### PR TITLE
Missing data dir fallback

### DIFF
--- a/examples/image_jepa/cfgs/default.yaml
+++ b/examples/image_jepa/cfgs/default.yaml
@@ -9,6 +9,7 @@ data:
   dataset: cifar10
   batch_size: 256
   num_workers: 4
+  data_dir: "eb_jepa/datasets"  # Default data directory path
 
 model:
   # Backbone

--- a/examples/image_jepa/main.py
+++ b/examples/image_jepa/main.py
@@ -392,7 +392,7 @@ def run(
     transform = get_train_transforms()
 
     # Use EBJEPA_DSETS environment variable if set, otherwise fall back to config
-    data_dir = os.environ.get("EBJEPA_DSETS")
+    data_dir = os.environ.get("EBJEPA_DSETS", cfg.data.data_dir)
     logger.info(f"Using data directory: {data_dir}")
 
     base_train_dataset = CIFAR10(


### PR DESCRIPTION
- Implement fallback logic in image_jepa main.py, as expressed in comment
- Add data_dir configuration in default.yaml with eb_jepa/datasets path