### PR TITLE
Fix/rollout parallel buffer

### DIFF
--- a/eb_jepa/architectures.py
+++ b/eb_jepa/architectures.py
@@ -477,8 +477,8 @@ class InverseDynamicsModel(nn.Module):
         """
         combined_states = torch.cat([state_t, state_t_plus_1], dim=1)
         return self.model(combined_states)
-     
-    
+
+
 class ActionEncoder(nn.Module):
     def __init__(self, dobs=2, hdim=256, dstc=16, hight=65, width=65):
         super().__init__()
@@ -492,7 +492,7 @@ class ActionEncoder(nn.Module):
         self.encoder = nn.Sequential(
             nn.Linear(self.dobs, self.hdim),
             nn.ReLU(),
-            nn.Linear(self.hdim, self.dstc * self.width * self.hight)
+            nn.Linear(self.hdim, self.dstc * self.width * self.hight),
         )
 
     def forward(self, x):
@@ -501,18 +501,18 @@ class ActionEncoder(nn.Module):
         b, c, t = x.shape
 
         # move encoding dimension to last
-        x = x.permute(0, 2, 1)          # (6,17,2)
+        x = x.permute(0, 2, 1)  # (6,17,2)
 
         # flatten untouched dimensions
-        x = x.reshape(-1, 2)            # (6*17,2)
+        x = x.reshape(-1, 2)  # (6*17,2)
 
         # encode
-        x = self.encoder(x)             # (6*17, 16*65*65)
+        x = self.encoder(x)  # (6*17, 16*65*65)
 
         # reshape back
-        x = x.view(b, t, self.dstc, self.hight, self.width)    # (6,17,16,65,65)
+        x = x.view(b, t, self.dstc, self.hight, self.width)  # (6,17,16,65,65)
 
         # final desired order
-        x = x.permute(0, 2, 1, 3, 4)    # (6,16,17,65,65)
+        x = x.permute(0, 2, 1, 3, 4)  # (6,16,17,65,65)
 
         return x

--- a/eb_jepa/architectures.py
+++ b/eb_jepa/architectures.py
@@ -105,7 +105,12 @@ class ResNet5(TemporalBatchMixin, nn.Module):
 
 
 class SimplePredictor(nn.Module):
-    """Wrapper that concatenates states and actions channel-wise before prediction."""
+    """Wrapper that concatenates states and actions channel-wise before prediction.
+
+    The context window stacking (building the multi-frame buffer) is handled externally
+    in the unroll() method. This wrapper simply concatenates the pre-built state buffer
+    with the action buffer (if provided) before forwarding to the underlying predictor.
+    """
 
     def __init__(self, predictor, context_length):
         super().__init__()
@@ -114,18 +119,9 @@ class SimplePredictor(nn.Module):
         self.context_length = context_length
 
     def forward(self, x, a):
-        return self.predictor(torch.cat([x, a], dim=1))
-
-
-class StateOnlyPredictor(SimplePredictor):
-    """Wrapper for a simple predictor which concatenates states and actions channel wise."""
-
-    def forward(self, x, a):
-        # action not used on purpose
-        prev_state = x[:, :, :-1]  # [B, C, T-1, H, W]
-        next_state = x[:, :, 1:]  # [B, C, T-1, H, W]
-        combined_xa = torch.cat((prev_state, next_state), dim=1)
-        return self.predictor(combined_xa)
+        if a is not None:
+            return self.predictor(torch.cat([x, a], dim=1))
+        return self.predictor(x)
 
 
 class ResUNet(TemporalBatchMixin, nn.Module):

--- a/eb_jepa/architectures.py
+++ b/eb_jepa/architectures.py
@@ -477,3 +477,36 @@ class InverseDynamicsModel(nn.Module):
         """
         combined_states = torch.cat([state_t, state_t_plus_1], dim=1)
         return self.model(combined_states)
+     
+    
+class ActionEncoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.encoder = nn.Sequential(
+            nn.Linear(2, 256),
+            nn.ReLU(),
+            nn.Linear(256, 16 * 65 * 65)
+        )
+
+    def forward(self, x):
+        # x shape: (6, 2, 17)
+
+        b, c, t = x.shape
+
+        # move encoding dimension to last
+        x = x.permute(0, 2, 1)          # (6,17,2)
+
+        # flatten untouched dimensions
+        x = x.reshape(-1, 2)            # (6*17,2)
+
+        # encode
+        x = self.encoder(x)             # (6*17, 16*65*65)
+
+        # reshape back
+        x = x.view(b, t, 16, 65, 65)    # (6,17,16,65,65)
+
+        # final desired order
+        x = x.permute(0, 2, 1, 3, 4)    # (6,16,17,65,65)
+
+        return x

--- a/eb_jepa/architectures.py
+++ b/eb_jepa/architectures.py
@@ -480,13 +480,19 @@ class InverseDynamicsModel(nn.Module):
      
     
 class ActionEncoder(nn.Module):
-    def __init__(self):
+    def __init__(self, dobs=2, hdim=256, dstc=16, hight=65, width=65):
         super().__init__()
 
+        self.dobs = dobs
+        self.dstc = dstc
+        self.width = width
+        self.hight = hight
+        self.hdim = hdim
+
         self.encoder = nn.Sequential(
-            nn.Linear(2, 256),
+            nn.Linear(self.dobs, self.hdim),
             nn.ReLU(),
-            nn.Linear(256, 16 * 65 * 65)
+            nn.Linear(self.hdim, self.dstc * self.width * self.hight)
         )
 
     def forward(self, x):
@@ -504,7 +510,7 @@ class ActionEncoder(nn.Module):
         x = self.encoder(x)             # (6*17, 16*65*65)
 
         # reshape back
-        x = x.view(b, t, 16, 65, 65)    # (6,17,16,65,65)
+        x = x.view(b, t, self.dstc, self.hight, self.width)    # (6,17,16,65,65)
 
         # final desired order
         x = x.permute(0, 2, 1, 3, 4)    # (6,16,17,65,65)

--- a/eb_jepa/jepa.py
+++ b/eb_jepa/jepa.py
@@ -122,7 +122,6 @@ class JEPA(JEPAbase):
               (total_loss, reg_loss, reg_loss_unweighted, reg_loss_dict, pred_loss)
         """
         state = self.encoder(observations)
-        print('state shape:', state.shape)
         B, C, T, H, W = state.shape
         context_length = getattr(self.predictor, "context_length", 0)
 
@@ -138,8 +137,6 @@ class JEPA(JEPAbase):
             actions_encoded = self.action_encoder(actions)
         else:
             actions_encoded = None
-
-        print('actions_encoded shape', actions_encoded.shape)
 
         # Collect all steps if requested
         all_steps = [] if return_all_steps else None
@@ -173,8 +170,6 @@ class JEPA(JEPAbase):
                 else:
                     action_buffer = None
 
-                print('state_buffer shape', state_buffer.shape)
-                print('action_buffer shape', action_buffer.shape)
                 predictor_out = self.predictor(state_buffer, action_buffer)
                 pred = predictor_out[:, :, :-1]  # (B, C, T'-1, H, W)
                 buffer.append(pred)  # drops oldest slot, adds latest prediction

--- a/eb_jepa/jepa.py
+++ b/eb_jepa/jepa.py
@@ -120,6 +120,7 @@ class JEPA(JEPAbase):
               (total_loss, reg_loss, reg_loss_unweighted, reg_loss_dict, pred_loss)
         """
         state = self.encoder(observations)
+        B, C, T, H, W = state.shape
         context_length = getattr(self.predictor, "context_length", 0)
 
         # Compute regularization loss if needed
@@ -138,23 +139,49 @@ class JEPA(JEPAbase):
         # Collect all steps if requested
         all_steps = [] if return_all_steps else None
 
-        # Parallel mode: process all timesteps at once, refeed GT context
+        # Parallel mode: process all timesteps at once using a rolling context buffer.
+        # At each step k, the context buffer contains:
+        #   - slots 0..L-2: real GT states shifted by k (anchor states)
+        #   - slot L-1: predictions from the previous step (propagated edge)
+        # This ensures real ground truth is used as context anchor whenever available.
         if unroll_mode == "parallel":
-            predicted_states = state
-            for _ in range(nsteps):
-                # Predict all timesteps, discard last (no target for it)
-                predicted_states = self.predictor(predicted_states, actions_encoded)[
-                    :, :, :-1
-                ]
-                # Collect step if requested
+            prev_predictions = None
+            for k in range(nsteps):
+                T_prime = T - context_length + 1 - k
+
+                if k == 0:
+                    state_slices = [
+                        state[:, :, i : i + T_prime] for i in range(context_length)
+                    ]
+                else:
+                    state_slices = [
+                        state[:, :, k + i : k + i + T_prime]
+                        for i in range(context_length - 1)
+                    ]
+                    state_slices.append(prev_predictions)
+
+                state_buffer = torch.cat(state_slices, dim=1)  # (B, C*L, T', H, W)
+
+                if actions_encoded is not None:
+                    action_slices = [
+                        actions_encoded[:, :, k + i : k + i + T_prime]
+                        for i in range(context_length)
+                    ]
+                    action_buffer = torch.cat(action_slices, dim=1)
+                else:
+                    action_buffer = None
+
+                predictor_out = self.predictor(state_buffer, action_buffer)
+                prev_predictions = predictor_out[:, :, :-1]  # (B, C, T'-1, H, W)
+
                 if return_all_steps:
-                    all_steps.append(predicted_states)
-                # Refeed ground truth context on the left
-                predicted_states = torch.cat(
-                    (state[:, :, :context_length], predicted_states), dim=2
-                )
+                    all_steps.append(prev_predictions)
+
                 if compute_loss:
-                    ploss += self.predcost(state, predicted_states) / nsteps
+                    target = state[:, :, context_length + k : T]
+                    ploss += self.predcost(target, prev_predictions) / nsteps
+
+            predicted_states = prev_predictions
 
         # Autoregressive mode: step-by-step with sliding window
         # Note: RNN predictors (is_rnn=True) are a special case with ctxt_window_time=1

--- a/eb_jepa/jepa.py
+++ b/eb_jepa/jepa.py
@@ -157,7 +157,7 @@ class JEPA(JEPAbase):
             )
             for k in range(nsteps):
                 T_prime = T - context_length + 1 - k
-                
+
                 state_slices = [s[:, :, :T_prime] for s in buffer]
                 state_buffer = torch.cat(state_slices, dim=1)  # (B, C*L, T', H, W)
 

--- a/eb_jepa/jepa.py
+++ b/eb_jepa/jepa.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 import torch
 import torch.nn as nn
 
@@ -120,6 +122,7 @@ class JEPA(JEPAbase):
               (total_loss, reg_loss, reg_loss_unweighted, reg_loss_dict, pred_loss)
         """
         state = self.encoder(observations)
+        print('state shape', state.shape)
         B, C, T, H, W = state.shape
         context_length = getattr(self.predictor, "context_length", 0)
 
@@ -139,28 +142,30 @@ class JEPA(JEPAbase):
         # Collect all steps if requested
         all_steps = [] if return_all_steps else None
 
-        # Parallel mode: process all timesteps at once using a rolling context buffer.
-        # At each step k, the context buffer contains:
-        #   - slots 0..L-2: real GT states shifted by k (anchor states)
-        #   - slot L-1: predictions from the previous step (propagated edge)
-        # This ensures real ground truth is used as context anchor whenever available.
+        # Parallel mode: rolling buffer of size context_length.
+        # The buffer starts filled with GT frames and progressively replaces
+        # the oldest slot with each new prediction:
+        #   step 1: [GT(1), GT(2), GT(3)]
+        #   step 2: [GT(2), GT(3), pred(1)]
+        #   step 3: [GT(3), pred(1), pred(2)]
+        #   step 4: [pred(1), pred(2), pred(3)]
+        # Older buffer slots are trimmed to the current T_prime as it shrinks.
         if unroll_mode == "parallel":
-            prev_predictions = None
+            T_prime_0 = T - context_length + 1
+            buffer = deque(
+                [state[:, :, i : i + T_prime_0] for i in range(context_length)],
+                maxlen=context_length,
+            )
+            print("Initial buffer len:", len(buffer), "  Expected: 1" )
             for k in range(nsteps):
                 T_prime = T - context_length + 1 - k
+                print('Step:', k)
+                print('T_prime', T_prime)
 
-                if k == 0:
-                    state_slices = [
-                        state[:, :, i : i + T_prime] for i in range(context_length)
-                    ]
-                else:
-                    state_slices = [
-                        state[:, :, k + i : k + i + T_prime]
-                        for i in range(context_length - 1)
-                    ]
-                    state_slices.append(prev_predictions)
-
+                state_slices = [s[:, :, :T_prime] for s in buffer]
+                print('Len of state slice:', len(state_slices))
                 state_buffer = torch.cat(state_slices, dim=1)  # (B, C*L, T', H, W)
+                print('state_buffer shape', state_buffer.shape)
 
                 if actions_encoded is not None:
                     action_slices = [
@@ -172,16 +177,17 @@ class JEPA(JEPAbase):
                     action_buffer = None
 
                 predictor_out = self.predictor(state_buffer, action_buffer)
-                prev_predictions = predictor_out[:, :, :-1]  # (B, C, T'-1, H, W)
+                pred = predictor_out[:, :, :-1]  # (B, C, T'-1, H, W)
+                buffer.append(pred)  # drops oldest slot, adds latest prediction
 
                 if return_all_steps:
-                    all_steps.append(prev_predictions)
+                    all_steps.append(pred)
 
                 if compute_loss:
                     target = state[:, :, context_length + k : T]
-                    ploss += self.predcost(target, prev_predictions) / nsteps
+                    ploss += self.predcost(target, pred) / nsteps
 
-            predicted_states = prev_predictions
+            predicted_states = pred
 
         # Autoregressive mode: step-by-step with sliding window
         # Note: RNN predictors (is_rnn=True) are a special case with ctxt_window_time=1

--- a/eb_jepa/jepa.py
+++ b/eb_jepa/jepa.py
@@ -122,6 +122,7 @@ class JEPA(JEPAbase):
               (total_loss, reg_loss, reg_loss_unweighted, reg_loss_dict, pred_loss)
         """
         state = self.encoder(observations)
+        print('state shape:', state.shape)
         B, C, T, H, W = state.shape
         context_length = getattr(self.predictor, "context_length", 0)
 
@@ -137,6 +138,8 @@ class JEPA(JEPAbase):
             actions_encoded = self.action_encoder(actions)
         else:
             actions_encoded = None
+
+        print('actions_encoded shape', actions_encoded.shape)
 
         # Collect all steps if requested
         all_steps = [] if return_all_steps else None
@@ -170,6 +173,8 @@ class JEPA(JEPAbase):
                 else:
                     action_buffer = None
 
+                print('state_buffer shape', state_buffer.shape)
+                print('action_buffer shape', action_buffer.shape)
                 predictor_out = self.predictor(state_buffer, action_buffer)
                 pred = predictor_out[:, :, :-1]  # (B, C, T'-1, H, W)
                 buffer.append(pred)  # drops oldest slot, adds latest prediction

--- a/eb_jepa/jepa.py
+++ b/eb_jepa/jepa.py
@@ -122,7 +122,6 @@ class JEPA(JEPAbase):
               (total_loss, reg_loss, reg_loss_unweighted, reg_loss_dict, pred_loss)
         """
         state = self.encoder(observations)
-        print('state shape', state.shape)
         B, C, T, H, W = state.shape
         context_length = getattr(self.predictor, "context_length", 0)
 
@@ -156,16 +155,11 @@ class JEPA(JEPAbase):
                 [state[:, :, i : i + T_prime_0] for i in range(context_length)],
                 maxlen=context_length,
             )
-            print("Initial buffer len:", len(buffer), "  Expected: 1" )
             for k in range(nsteps):
                 T_prime = T - context_length + 1 - k
-                print('Step:', k)
-                print('T_prime', T_prime)
-
+                
                 state_slices = [s[:, :, :T_prime] for s in buffer]
-                print('Len of state slice:', len(state_slices))
                 state_buffer = torch.cat(state_slices, dim=1)  # (B, C*L, T', H, W)
-                print('state_buffer shape', state_buffer.shape)
 
                 if actions_encoded is not None:
                     action_slices = [

--- a/eb_jepa/state_decoder.py
+++ b/eb_jepa/state_decoder.py
@@ -2,9 +2,40 @@ from torch import nn
 
 
 class MLPXYHead(nn.Module):
-    """A head to recover the xy location from features."""
+    """A head to recover the xy location from features with 1x1 spatial dims."""
 
-    def __init__(self, input_shape, normalizer=None):  # input_shape = (C, H, W)
+    def __init__(self, input_shape, normalizer=None):  # input_shape = C
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(input_shape, 512), nn.ReLU(inplace=True), nn.Linear(512, 2)
+        )
+        self.normalizer = normalizer
+
+    def forward(self, x):
+        """
+        Args:
+            x: [B, C, T, 1, 1]
+        Returns:
+            pred: [B, 2, T]
+        """
+        bs, c, t, h, w = x.shape
+
+        x = x.permute(0, 2, 1, 3, 4)  # [B, T, C, H, W]
+        x = x.reshape(bs * t, c, h, w)  # [B*T, C, H, W]
+
+        x = x.squeeze(-1).squeeze(-1)  # [B*T, C]
+
+        pred = self.mlp(x)
+
+        pred = pred.view(bs, t, 2).permute(0, 2, 1)
+
+        return pred
+
+
+class SpatialMLPXYHead(nn.Module):
+    """A head to recover the xy location from spatial feature maps (H, W > 1)."""
+
+    def __init__(self, input_shape, normalizer=None):  # input_shape = C * H * W
         super().__init__()
         self.mlp = nn.Sequential(
             nn.Linear(input_shape, 512), nn.ReLU(inplace=True), nn.Linear(512, 2)
@@ -21,9 +52,7 @@ class MLPXYHead(nn.Module):
         bs, c, t, h, w = x.shape
 
         x = x.permute(0, 2, 1, 3, 4)  # [B, T, C, H, W]
-        x = x.reshape(bs * t, c, h, w)  # [B*T, C, H, W]
-
-        x = x.squeeze(-1).squeeze(-1)  # [B*T, C]
+        x = x.reshape(bs * t, c * h * w)  # [B*T, C*H*W]
 
         pred = self.mlp(x)
 

--- a/examples/ac_video_parallel_jepa/README.md
+++ b/examples/ac_video_parallel_jepa/README.md
@@ -1,0 +1,88 @@
+# Example - Action Conditioned Video JEPA (Parallel / Spatial)
+
+This example demonstrates a Joint Embedding Predictive Architecture (JEPA) for action-conditioned world modeling in the Two Rooms environment, using a **non-recurrent, spatially-structured** architecture. It extends `examples/video_jepa` with actions, and serves as an architectural alternative to `examples/ac_video_jepa`.
+
+## Overview
+
+This example shares the same learning objective as [`examples/ac_video_jepa`](../ac_video_jepa/README.md) — learning to predict future visual embeddings conditioned on actions — but makes two fundamental architectural choices that distinguish it:
+
+1. **Non-recurrent predictor** (ResUNet + `SimplePredictor`): instead of a recurrent RNN that processes one step at a time, predictions are produced over a context window in parallel, following the same design as `examples/video_jepa` but with actions as additional input.
+
+2. **Spatial encoder** (ResNet5): instead of the ImpalaEncoder which collapses spatial dimensions into a single global vector `[B, D, T, 1, 1]`, ResNet5 preserves the full spatial structure of feature maps `[B, C, T, H, W]`. This choice has cascading architectural consequences described below.
+
+| Component | `ac_video_jepa` | `ac_video_parallel_jepa` (this example) |
+|-----------|-----------------|----------------------------------------|
+| Encoder | ImpalaEncoder → `[B, D, T, 1, 1]` | ResNet5 → `[B, C, T, H, W]` |
+| Predictor | RNNPredictor (recurrent, sequential) | ResUNet + SimplePredictor (non-recurrent, parallel) |
+| Action Encoder | Identity (action fed directly to RNN) | ActionEncoder (broadcasts action → spatial tensor) |
+| Probe Head | MLPXYHead (squeezes 1×1 spatial dims) | SpatialMLPXYHead (flattens C×H×W) |
+| Unroll mode | Sequential / autoregressive | Parallel (sliding context window buffer) |
+
+## Training
+
+### Architecture
+
+1. **Encoder** (ResNet5): Maps each observation frame to a spatial feature map.
+   - Input: `[B, C_obs, T, H, W]`
+   - Output: `[B, dstc, T, H, W]` — spatial dims are preserved throughout
+
+2. **Predictor** (ResUNet + SimplePredictor): Predicts the next representation from a context window of past encoded states and actions. The predictor is non-recurrent: it takes a stacked context buffer of `ctxtwind` frames and outputs the next predicted representation in a single forward pass.
+   - Input channels: `ctxtwind × 2 × dstc` (stacked encoded states concatenated channel-wise with encoded actions)
+   - No hidden state is maintained across steps; the context window is a sliding buffer
+
+3. **Action Encoder** (ActionEncoder): Encodes a 2D action vector into a spatial tensor that can be concatenated channel-wise with the ResNet5 feature maps.
+   - This component is required because the ResUNet predictor operates on spatial tensors `[B, C, T, H, W]`. A raw 2D action cannot be concatenated directly — it must first be projected and reshaped to match the spatial dimensions of the encoded states.
+   - Architecture: two-layer MLP with hidden dim `hactenc`, output reshaped to `[B, dstc, T, H, W]`
+
+4. **Regularizer**: Same VC + IDM + time-similarity regularization as `ac_video_jepa`. See that README for details.
+
+5. **Probe Head** (SpatialMLPXYHead): Decodes the agent's (x, y) position from encoder representations.
+   - Because ResNet5 preserves spatial dims, the standard `MLPXYHead` (which assumes 1×1 spatial dims and uses `squeeze`) cannot be used here. `SpatialMLPXYHead` instead flattens `C × H × W` into a single vector before the linear probe.
+   - Input shape: `C × H × W` (e.g. `16 × 65 × 65`)
+
+### Training Objectives
+
+Same loss terms as `ac_video_jepa`:
+
+$$L = L_{\text{pred}} + \beta L_{\text{cov}} + \alpha L_{\text{var}} + \delta L_{\text{time-sim}} + \omega L_{\text{IDM}}$$
+
+See [`examples/ac_video_jepa`](../ac_video_jepa/README.md#training-objectives) for the full formulation.
+
+### Training Data
+
+Same Two Rooms environment as `ac_video_jepa`. See that README for details on the fixed wall and random wall setups.
+
+### Usage
+
+```bash
+# Train a model locally
+python -m examples.ac_video_parallel_jepa.main \
+  --fname examples/ac_video_parallel_jepa/cfgs/train.yaml
+
+# Launch with sbatch
+python -m examples.launch_sbatch --example ac_video_parallel_jepa
+```
+
+Key configuration parameters (`cfgs/train.yaml`):
+
+| Parameter | Description |
+|-----------|-------------|
+| `model.dstc` | Representation dimension (encoder output channels) |
+| `model.henc` | ResNet5 hidden dim |
+| `model.hpre` | ResUNet hidden dim |
+| `model.ctxtwind` | Context window size for SimplePredictor |
+| `model.hactenc` | Hidden dim of the ActionEncoder MLP |
+| `model.nsteps` | Number of prediction steps during training |
+
+## Evaluation
+
+Unrolling and planning evaluation follow the same procedure as `ac_video_jepa`. See that README for full details on unrolling evaluation, planning with MPPI/CEM, and evaluation episode definition.
+
+## References
+- [JEPA Paper](https://openreview.net/pdf?id=BZ5a1r-kVsf)
+- [PLDM and Two-Rooms Environment](https://arxiv.org/abs/2502.14819)
+- [ResNet Architecture](https://arxiv.org/abs/1512.03385)
+- [VICReg](https://arxiv.org/abs/2105.04906)
+- [JEPA Slow Features](https://arxiv.org/abs/2211.10831)
+- [MPPI](https://arxiv.org/abs/1509.01149)
+- [CEM](https://asco.lcsr.jhu.edu/papers/Ko2012.pdf)

--- a/examples/ac_video_parallel_jepa/cfgs/train.yaml
+++ b/examples/ac_video_parallel_jepa/cfgs/train.yaml
@@ -9,15 +9,15 @@ logging:
 meta:
   model_folder:
   load_model: true
-  enable_plan_eval: true
+  enable_plan_eval: false
   eval_every_itr: -1
   light_eval_freq: 50
   seed: 1
 data:
   env_name: two_rooms
   # Training-specific overrides (base config in eb_jepa/datasets/two_rooms/data_config.yaml)
-  batch_size: 384
-  num_workers: 16
+  batch_size: 6
+  num_workers: 1
   pin_mem: true
   persistent_workers: true
 training:
@@ -25,13 +25,24 @@ training:
   dtype: bfloat16
 model:
   # Encoder (ResNet5)
-  dobs: 1           # Input channels (grayscale)
+  dobs: 2           # Input channels (grayscale)
   henc: 32          # Hidden dimension in encoder
   dstc: 16          # Output representation dimension
   # Predictor (ResUNet)
   hpre: 32          # Hidden dimension in predictor
   # Training
-  steps: 5          # Number of prediction steps during training
+  nsteps: 3         # Number of prediction steps during training
+  encoder_architecture: resnet
+  compile: false
+  regularizer:
+    cov_coeff: 8
+    std_coeff: 16 # 4.0
+    sim_coeff_t: 12 # 0.75 in PLDM
+    idm_coeff: 1
+    use_proj: false
+    idm_after_proj: false
+    spatial_as_samples: true
+    sim_t_after_proj: false
 optim:
   epochs: 12
   lr: 0.001

--- a/examples/ac_video_parallel_jepa/cfgs/train.yaml
+++ b/examples/ac_video_parallel_jepa/cfgs/train.yaml
@@ -25,11 +25,14 @@ training:
   dtype: bfloat16
 model:
   # Encoder (ResNet5)
-  dobs: 2           # Input channels (grayscale)
+  dobs: 2           # Input channels
   henc: 32          # Hidden dimension in encoder
   dstc: 16          # Output representation dimension
   # Predictor (ResUNet)
   hpre: 32          # Hidden dimension in predictor
+  ctxtwind: 3       # Context window
+  # Action encoder
+  hactenc: 256
   # Training
   nsteps: 3         # Number of prediction steps during training
   encoder_architecture: resnet

--- a/examples/ac_video_parallel_jepa/cfgs/train.yaml
+++ b/examples/ac_video_parallel_jepa/cfgs/train.yaml
@@ -1,0 +1,54 @@
+logging:
+  log_wandb: true
+  wandb_group:
+  wandb_sweep:
+  log_every: 10
+  exp_suffix: 26-01-15
+  save_every_n_epochs: 1
+  tqdm_silent: false
+meta:
+  model_folder:
+  load_model: true
+  enable_plan_eval: true
+  eval_every_itr: -1
+  light_eval_freq: 50
+  seed: 1
+data:
+  env_name: two_rooms
+  # Training-specific overrides (base config in eb_jepa/datasets/two_rooms/data_config.yaml)
+  batch_size: 384
+  num_workers: 16
+  pin_mem: true
+  persistent_workers: true
+training:
+  use_amp: true
+  dtype: bfloat16
+model:
+  # Encoder (ResNet5)
+  dobs: 1           # Input channels (grayscale)
+  henc: 32          # Hidden dimension in encoder
+  dstc: 16          # Output representation dimension
+  # Predictor (ResUNet)
+  hpre: 32          # Hidden dimension in predictor
+  # Training
+  steps: 5          # Number of prediction steps during training
+optim:
+  epochs: 12
+  lr: 0.001
+  grad_clip_enc: 2.0
+  grad_clip_pred: 2.0
+  weight_decay: 1.e-5
+eval:
+  plan_cfg_path: examples/ac_video_jepa/cfgs/planning_mppi.yaml # eb_jepa/planning_mppi.yaml
+  eval_cfg_path: examples/ac_video_jepa/cfgs/eval.yaml
+
+# --- Parameters used when running with --full-sweep
+# By default, only the parameters specified above are used
+sweep:
+  # Sweep grid for AC video JEPA hyperparameter search
+  param_grid:
+    model.regularizer.cov_coeff: [8, 12]
+    model.regularizer.std_coeff: [8, 16]
+    model.regularizer.sim_coeff_t: [8, 12, 16]
+    model.regularizer.idm_coeff: [1, 2]
+    meta.seed: [1, 1000, 10000]

--- a/examples/ac_video_parallel_jepa/main.py
+++ b/examples/ac_video_parallel_jepa/main.py
@@ -20,6 +20,7 @@ from eb_jepa.architectures import (
     ResUNet,
     SimplePredictor,
     InverseDynamicsModel,
+    ActionEncoder,
 )
 from eb_jepa.datasets.utils import init_data
 from eb_jepa.jepa import JEPA, JEPAProbe
@@ -48,7 +49,7 @@ logger = get_logger(__name__)
 
 
 def run(
-    fname: str = "examples/ac_video_jepa/cfgs/train.yaml",
+    fname: str = "examples/ac_video_parallel_jepa/cfgs/train.yaml",
     cfg=None,
     folder=None,
     **overrides,
@@ -174,12 +175,15 @@ def run(
         )
     )
     encoder = ResNet5(cfg.model.dobs, cfg.model.henc, cfg.model.dstc)
-    predictor = ResUNet(3 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
+    predictor = ResUNet(4 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
+    predictor = SimplePredictor(predictor, context_length=2)
+
 
     test_output = encoder(test_input)
     _, f, _, h, w = test_output.shape
     
-    aencoder = nn.Identity()
+    aencoder = ActionEncoder()
+    
     if cfg.model.regularizer.use_proj:
         projector = Projector(
             f"{encoder.mlp_output_dim}-{encoder.mlp_output_dim*4}-{encoder.mlp_output_dim*4}"
@@ -311,12 +315,12 @@ def run(
             # Calculate JEPA loss
             jepa_optimizer.zero_grad()
             with autocast(device.type, enabled=use_amp, dtype=dtype):
+                print('x shape:', x.shape)
                 _, (jepa_loss, regl, regl_unweight, regldict, pl) = jepa.unroll(
                     x,
                     a,
                     nsteps=cfg.model.nsteps,
-                    unroll_mode="autoregressive",
-                    ctxt_window_time=1,
+                    unroll_mode="parallel",
                     compute_loss=True,
                     return_all_steps=False,
                 )

--- a/examples/ac_video_parallel_jepa/main.py
+++ b/examples/ac_video_parallel_jepa/main.py
@@ -27,7 +27,7 @@ from eb_jepa.jepa import JEPA, JEPAProbe
 from eb_jepa.logging import get_logger
 from eb_jepa.losses import SquareLossSeq, VC_IDM_Sim_Regularizer
 from eb_jepa.schedulers import CosineWithWarmup
-from eb_jepa.state_decoder import MLPXYHead
+from eb_jepa.state_decoder import SpatialMLPXYHead
 from eb_jepa.training_utils import (
     get_default_dev_name,
     get_exp_name,
@@ -174,15 +174,17 @@ def run(
             data_config.img_size,
         )
     )
+    
+    context_lenght = cfg.model.ctxtwind
     encoder = ResNet5(cfg.model.dobs, cfg.model.henc, cfg.model.dstc)
-    predictor = ResUNet(4 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
-    predictor = SimplePredictor(predictor, context_length=2)
-
-
+    # In input we would concatenate sensor encoding and action times the number of contenxt window
+    predictor = ResUNet(context_lenght * 2 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
+    predictor = SimplePredictor(predictor, context_length=context_lenght)
+    
     test_output = encoder(test_input)
     _, f, _, h, w = test_output.shape
-    
-    aencoder = ActionEncoder()
+        
+    aencoder = ActionEncoder(hdim=cfg.model.hactenc, dstc=cfg.model.dstc, hight=h, width=w)
     
     if cfg.model.regularizer.use_proj:
         projector = Projector(
@@ -222,8 +224,8 @@ def run(
     log_config(cfg)
 
     # -- PROBER
-    xy_head = MLPXYHead(
-        input_shape=test_output.shape[1],
+    xy_head = SpatialMLPXYHead(
+        input_shape=f * h * w,
         normalizer=loader.dataset.normalizer,
     ).to(device)
     xy_prober = JEPAProbe(
@@ -315,7 +317,6 @@ def run(
             # Calculate JEPA loss
             jepa_optimizer.zero_grad()
             with autocast(device.type, enabled=use_amp, dtype=dtype):
-                print('x shape:', x.shape)
                 _, (jepa_loss, regl, regl_unweight, regldict, pl) = jepa.unroll(
                     x,
                     a,

--- a/examples/ac_video_parallel_jepa/main.py
+++ b/examples/ac_video_parallel_jepa/main.py
@@ -14,13 +14,12 @@ from torch.optim import AdamW
 from tqdm import tqdm
 
 from eb_jepa.architectures import (
-    DetHead,
+    ActionEncoder,
+    InverseDynamicsModel,
     Projector,
     ResNet5,
     ResUNet,
     SimplePredictor,
-    InverseDynamicsModel,
-    ActionEncoder,
 )
 from eb_jepa.datasets.utils import init_data
 from eb_jepa.jepa import JEPA, JEPAProbe
@@ -174,18 +173,22 @@ def run(
             data_config.img_size,
         )
     )
-    
+
     context_lenght = cfg.model.ctxtwind
     encoder = ResNet5(cfg.model.dobs, cfg.model.henc, cfg.model.dstc)
     # In input we would concatenate sensor encoding and action times the number of contenxt window
-    predictor = ResUNet(context_lenght * 2 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
+    predictor = ResUNet(
+        context_lenght * 2 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc
+    )
     predictor = SimplePredictor(predictor, context_length=context_lenght)
-    
+
     test_output = encoder(test_input)
     _, f, _, h, w = test_output.shape
-        
-    aencoder = ActionEncoder(hdim=cfg.model.hactenc, dstc=cfg.model.dstc, hight=h, width=w)
-    
+
+    aencoder = ActionEncoder(
+        hdim=cfg.model.hactenc, dstc=cfg.model.dstc, hight=h, width=w
+    )
+
     if cfg.model.regularizer.use_proj:
         projector = Projector(
             f"{encoder.mlp_output_dim}-{encoder.mlp_output_dim*4}-{encoder.mlp_output_dim*4}"

--- a/examples/ac_video_parallel_jepa/main.py
+++ b/examples/ac_video_parallel_jepa/main.py
@@ -1,0 +1,474 @@
+import copy
+import os
+from pathlib import Path
+from time import time
+
+import fire
+import torch
+import torch.nn as nn
+import wandb
+import yaml
+from omegaconf import OmegaConf
+from torch.amp import GradScaler, autocast
+from torch.optim import AdamW
+from tqdm import tqdm
+
+from eb_jepa.architectures import (
+    DetHead,
+    Projector,
+    ResNet5,
+    ResUNet,
+    SimplePredictor,
+    InverseDynamicsModel,
+)
+from eb_jepa.datasets.utils import init_data
+from eb_jepa.jepa import JEPA, JEPAProbe
+from eb_jepa.logging import get_logger
+from eb_jepa.losses import SquareLossSeq, VC_IDM_Sim_Regularizer
+from eb_jepa.schedulers import CosineWithWarmup
+from eb_jepa.state_decoder import MLPXYHead
+from eb_jepa.training_utils import (
+    get_default_dev_name,
+    get_exp_name,
+    get_unified_experiment_dir,
+    load_checkpoint,
+    load_config,
+    log_config,
+    log_data_info,
+    log_epoch,
+    log_model_info,
+    save_checkpoint,
+    setup_device,
+    setup_seed,
+    setup_wandb,
+)
+from examples.ac_video_jepa.eval import launch_plan_eval, launch_unroll_eval
+
+logger = get_logger(__name__)
+
+
+def run(
+    fname: str = "examples/ac_video_jepa/cfgs/train.yaml",
+    cfg=None,
+    folder=None,
+    **overrides,
+):
+    """
+    Train an action-conditioned Video JEPA model.
+
+    Args:
+        fname: Path to the YAML config file.
+        cfg: Pre-loaded config object (optional, overrides config file).
+        folder: Experiment folder path (optional, auto-generated if not provided).
+        **overrides: Config overrides in dot notation (e.g., model.henc=64).
+    """
+    if cfg is None:
+        cfg = load_config(fname, overrides if overrides else None)
+
+    # Create experiment directory using unified structure (if not provided)
+    if folder is None:
+        if cfg.meta.get("model_folder"):
+            folder = Path(cfg.meta.model_folder)
+            folder_name = folder.name
+            exp_name = folder_name.rsplit("_seed", 1)[0]
+        else:
+            sweep_name = get_default_dev_name()
+            exp_name = get_exp_name("ac_video_jepa", cfg)
+            folder = get_unified_experiment_dir(
+                example_name="ac_video_jepa",
+                sweep_name=sweep_name,
+                exp_name=exp_name,
+                seed=cfg.meta.seed,
+            )
+    else:
+        folder = Path(folder)
+        folder_name = folder.name
+        exp_name = folder_name.rsplit("_seed", 1)[0]
+
+    os.makedirs(folder, exist_ok=True)
+
+    loader, val_loader, data_config = init_data(
+        env_name=cfg.data.env_name, cfg_data=dict(cfg.data)
+    )
+
+    # -- SETUP
+    setup_device("auto")
+    setup_seed(cfg.meta.seed)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # -- WANDB
+    wandb_run = setup_wandb(
+        project="eb_jepa",
+        config={
+            "example": "ac_video_jepa",
+            **OmegaConf.to_container(cfg, resolve=True),
+        },
+        run_dir=folder,
+        run_name=exp_name,
+        tags=[f"seed_{cfg.meta.seed}", "ac_video_jepa"],
+        group=cfg.logging.get("wandb_group"),
+        enabled=cfg.logging.get("log_wandb", False),
+        sweep_id=cfg.logging.get("wandb_sweep_id"),
+    )
+
+    log_data_info(
+        cfg.data.env_name,
+        len(loader),
+        data_config.batch_size,
+        train_samples=data_config.size,
+        val_samples=data_config.val_size,
+    )
+
+    # Mixed precision setup
+    dtype_map = {"bfloat16": torch.bfloat16, "float16": torch.float16}
+    dtype = dtype_map.get(cfg.training.get("dtype", "float16").lower(), torch.float16)
+    use_amp = cfg.training.get("use_amp", True)
+    scaler = GradScaler(device.type, enabled=use_amp)
+    logger.info(f"Using AMP with {dtype=}" if use_amp else f"AMP disabled")
+
+    # -- ENV (for plan/unroll eval)
+    enable_eval = cfg.meta.get("enable_plan_eval", False)
+    env_creator = None
+    plan_cfg = None
+    num_eval_episodes = 10
+
+    if enable_eval:
+        if cfg.meta.eval_every_itr <= 0:
+            cfg.meta.eval_every_itr = len(loader)
+        with open(cfg.eval.plan_cfg_path, "r") as f:
+            plan_cfg = yaml.load(f, Loader=yaml.FullLoader)
+        plan_cfg["logging"] = copy.deepcopy(dict(cfg.logging))
+        with open(cfg.eval.eval_cfg_path, "r") as f:
+            eval_cfg_dict = yaml.safe_load(f)
+        _, _, env_config = init_data(
+            env_name=cfg.data.env_name, cfg_data=dict(eval_cfg_dict.get("data", {}))
+        )
+        num_eval_episodes = eval_cfg_dict.get("meta", {}).get("num_eval_episodes", 10)
+
+        def env_creator():
+            from eb_jepa.datasets.two_rooms.env import DotWall
+
+            cfg_eval_env = eval_cfg_dict.get("env")
+            return DotWall(
+                config=env_config,
+                **cfg_eval_env,
+            )
+
+    # -- SAVE CONFIG
+    latest_ckpt_path = folder / "latest.pth.tar"
+    steps_per_epoch = data_config.size // data_config.batch_size
+    total_steps = cfg.optim.epochs * steps_per_epoch
+    config_path = folder / "config.yaml"
+    with open(config_path, "w") as f:
+        OmegaConf.save(cfg, config_path)
+    print(f"Saved complete config to {config_path}")
+
+    # -- MODEL
+    test_input = torch.rand(
+        (
+            1,
+            cfg.model.dobs,
+            1,
+            data_config.img_size,
+            data_config.img_size,
+        )
+    )
+    encoder = ResNet5(cfg.model.dobs, cfg.model.henc, cfg.model.dstc)
+    predictor = ResUNet(3 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
+
+    test_output = encoder(test_input)
+    _, f, _, h, w = test_output.shape
+    
+    aencoder = nn.Identity()
+    if cfg.model.regularizer.use_proj:
+        projector = Projector(
+            f"{encoder.mlp_output_dim}-{encoder.mlp_output_dim*4}-{encoder.mlp_output_dim*4}"
+        )
+    else:
+        projector = None
+    logger.info(f"Encoder output: {tuple(test_output.shape)}")
+    idm = InverseDynamicsModel(
+        state_dim=h
+        * w
+        * (projector.out_dim if cfg.model.regularizer.idm_after_proj else f),
+        hidden_dim=256,
+        action_dim=2,
+    ).to(device)
+
+    regularizer = VC_IDM_Sim_Regularizer(
+        cov_coeff=cfg.model.regularizer.cov_coeff,
+        std_coeff=cfg.model.regularizer.std_coeff,
+        sim_coeff_t=cfg.model.regularizer.sim_coeff_t,
+        idm_coeff=cfg.model.regularizer.get("idm_coeff", 0.1),
+        idm=idm,
+        first_t_only=cfg.model.regularizer.get("first_t_only"),
+        projector=projector,
+        spatial_as_samples=cfg.model.regularizer.spatial_as_samples,
+        idm_after_proj=cfg.model.regularizer.idm_after_proj,
+        sim_t_after_proj=cfg.model.regularizer.sim_t_after_proj,
+    )
+    ploss = SquareLossSeq()
+    jepa = JEPA(encoder, aencoder, predictor, regularizer, ploss).to(device)
+
+    # Log model structure and parameters
+    encoder_params = sum(p.numel() for p in encoder.parameters())
+    predictor_params = sum(p.numel() for p in predictor.parameters())
+    log_model_info(jepa, {"encoder": encoder_params, "predictor": predictor_params})
+
+    log_config(cfg)
+
+    # -- PROBER
+    xy_head = MLPXYHead(
+        input_shape=test_output.shape[1],
+        normalizer=loader.dataset.normalizer,
+    ).to(device)
+    xy_prober = JEPAProbe(
+        jepa=jepa,
+        head=xy_head,
+        hcost=nn.MSELoss(),
+    )
+
+    jepa_optimizer = AdamW(
+        jepa.parameters(),
+        lr=cfg.optim.lr,
+        weight_decay=cfg.optim.get("weight_decay", 1e-6),
+    )
+    jepa_scheduler = CosineWithWarmup(jepa_optimizer, total_steps, warmup_ratio=0.1)
+
+    probe_optimizer = AdamW(xy_head.parameters(), lr=1e-3, weight_decay=1e-5)
+    probe_scheduler = CosineWithWarmup(probe_optimizer, total_steps, warmup_ratio=0.1)
+
+    # -- LOAD CKPT
+    start_epoch = 0
+    ckpt_info = {}
+    if cfg.meta.load_model:
+        checkpoint_path = folder / cfg.meta.get("load_checkpoint", "latest.pth.tar")
+        ckpt_info = load_checkpoint(
+            checkpoint_path, jepa, jepa_optimizer, jepa_scheduler, device=device
+        )
+        start_epoch = ckpt_info.get("epoch", 0)
+        if "xy_head_state_dict" in ckpt_info:
+            xy_head.load_state_dict(ckpt_info["xy_head_state_dict"])
+
+    # Compile
+    if torch.cuda.is_available() and cfg.model.compile:
+        logger.info("✅ Compiling model with torch.compile")
+        jepa = torch.compile(jepa)
+
+    # -- EVAL ONLY MODE
+    if cfg.meta.get("eval_only_mode", False):
+        if not enable_eval:
+            raise ValueError("eval_only_mode requires enable_plan_eval=True")
+        logger.info("Running evaluation only (no training)")
+        eval_results = launch_unroll_eval(
+            jepa,
+            env_creator,
+            folder,
+            start_epoch,
+            ckpt_info.get("step", 0),
+            "_eval_only",
+            val_loader,
+            xy_prober,
+            cfg,
+        )
+        eval_results.update(
+            launch_plan_eval(
+                jepa,
+                env_creator,
+                folder,
+                start_epoch,
+                global_step=ckpt_info.get("step", 0),
+                suffix="_eval_only",
+                num_eval_episodes=num_eval_episodes,
+                loader=val_loader,
+                prober=xy_prober,
+                plan_cfg=plan_cfg,
+            )
+        )
+        logger.info(
+            f"Evaluation complete. Success rate: {eval_results['success_rate']:.2%}"
+        )
+        return eval_results
+
+    # -- TRAINING LOOP
+    for epoch in range(start_epoch, cfg.optim.epochs):
+        epoch_start_time = time()
+        pbar = tqdm(
+            enumerate(loader),
+            total=len(loader),
+            desc=f"Epoch {epoch}/{cfg.optim.epochs - 1}",
+            disable=cfg.logging.get("tqdm_silent", False),
+        )
+        for idx, (x, a, loc, _, _) in pbar:
+            itr_start_time = time()
+            global_step = epoch * len(loader) + idx
+
+            x = x.to(device)
+            a = a.to(device)
+            loc = loc.to(device)
+            total_loss = torch.tensor(0.0, device=device)
+
+            # Calculate JEPA loss
+            jepa_optimizer.zero_grad()
+            with autocast(device.type, enabled=use_amp, dtype=dtype):
+                _, (jepa_loss, regl, regl_unweight, regldict, pl) = jepa.unroll(
+                    x,
+                    a,
+                    nsteps=cfg.model.nsteps,
+                    unroll_mode="autoregressive",
+                    ctxt_window_time=1,
+                    compute_loss=True,
+                    return_all_steps=False,
+                )
+                total_loss += jepa_loss
+
+            # Mixed precision backward pass
+            scaler.scale(jepa_loss).backward()
+            if cfg.optim.get("grad_clip_enc") and cfg.optim.get("grad_clip_pred"):
+                scaler.unscale_(jepa_optimizer)
+                torch.nn.utils.clip_grad_norm_(
+                    jepa.encoder.parameters(), cfg.optim.grad_clip_enc
+                )
+                torch.nn.utils.clip_grad_norm_(
+                    jepa.predictor.parameters(), cfg.optim.grad_clip_pred
+                )
+            scaler.step(jepa_optimizer)
+            scaler.update()
+            jepa_scheduler.step()
+
+            # Calculate probe loss
+            probe_optimizer.zero_grad()
+            with autocast(device.type, enabled=use_amp, dtype=dtype):
+                xy_loss = xy_prober(
+                    observations=x[:, :, :1],
+                    targets=loc[:, :, :1],
+                )
+                xy_loss = loader.dataset.normalizer.unnormalize_mse(xy_loss)
+                total_loss += xy_loss
+
+            scaler.scale(xy_loss).backward()
+            scaler.step(probe_optimizer)
+            scaler.update()
+            probe_scheduler.step()
+
+            # Update progress bar
+            pbar.set_postfix(
+                {
+                    "loss": f"{total_loss.item():.4f}",
+                    "reg": f"{regl.item():.4f}",
+                    "pred": f"{pl.item():.4f}",
+                }
+            )
+
+            itr_time = time() - itr_start_time
+            if global_step % cfg.logging.log_every == 0:
+                log_data = {
+                    "train/total_loss": total_loss.item(),
+                    "train/reg_loss": regl.item(),
+                    "train/reg_loss_unweight": regl_unweight.item(),
+                    "train/pred_loss": pl.item(),
+                    "train/probe_loss": xy_loss.item(),
+                    "global_step": global_step,
+                    "epoch": epoch,
+                    "itr_time": itr_time,
+                    "optim/jepa_lr": jepa_optimizer.param_groups[0]["lr"],
+                    "optim/probe_lr": probe_optimizer.param_groups[0]["lr"],
+                }
+                for loss_name, loss_value in regldict.items():
+                    log_data[f"train/regl/{loss_name}"] = loss_value
+
+                if cfg.logging.get("log_wandb"):
+                    wandb.log(log_data, step=global_step)
+
+            # Planning eval (only if eval is enabled)
+            if (
+                enable_eval
+                and (global_step + 1) % cfg.meta.eval_every_itr == 0
+                and global_step > 0
+            ):
+                eval_results = launch_plan_eval(
+                    jepa,
+                    env_creator,
+                    folder,
+                    epoch,
+                    global_step,
+                    suffix="",
+                    num_eval_episodes=num_eval_episodes,
+                    loader=val_loader,
+                    prober=xy_prober,
+                    plan_cfg=plan_cfg,
+                )
+
+                if cfg.logging.get("log_wandb"):
+                    wandb.log(eval_results, step=global_step)
+
+            # Light eval (only if eval is enabled)
+            if (
+                enable_eval
+                and (global_step + 1) % cfg.meta.light_eval_freq == 0
+                and global_step > 0
+            ):
+                eval_results = launch_unroll_eval(
+                    jepa,
+                    env_creator,
+                    folder,
+                    epoch,
+                    global_step,
+                    suffix="",
+                    loader=val_loader,
+                    prober=xy_prober,
+                    cfg=cfg,
+                )
+
+                if cfg.logging.get("log_wandb"):
+                    wandb.log(eval_results, step=global_step)
+
+        epoch_time = time() - epoch_start_time
+
+        # Log epoch summary
+        log_epoch(
+            epoch,
+            {
+                "loss": total_loss.item(),
+                "reg": regl.item(),
+                "pred": pl.item(),
+                "probe": xy_loss.item(),
+            },
+            total_epochs=cfg.optim.epochs,
+            elapsed_time=epoch_time,
+        )
+
+        if cfg.logging.get("log_wandb"):
+            wandb.log(
+                {"epoch": epoch, "epoch_time": epoch_time},
+                step=epoch * len(loader),
+            )
+
+        # Save checkpoint
+        save_checkpoint(
+            latest_ckpt_path,
+            model=jepa,
+            optimizer=jepa_optimizer,
+            scheduler=jepa_scheduler,
+            epoch=epoch,
+            step=global_step,
+            xy_head_state_dict=xy_head.state_dict(),
+            probe_optimizer_state_dict=probe_optimizer.state_dict(),
+            probe_scheduler_state_dict=probe_scheduler.state_dict(),
+        )
+        if epoch % cfg.logging.save_every_n_epochs == 0:
+            save_checkpoint(
+                folder / f"e-{epoch}.pth.tar",
+                model=jepa,
+                optimizer=jepa_optimizer,
+                scheduler=jepa_scheduler,
+                epoch=epoch,
+                step=global_step,
+                xy_head_state_dict=xy_head.state_dict(),
+                probe_optimizer_state_dict=probe_optimizer.state_dict(),
+                probe_scheduler_state_dict=probe_scheduler.state_dict(),
+            )
+
+
+if __name__ == "__main__":
+    fire.Fire(run)

--- a/examples/video_jepa/main.py
+++ b/examples/video_jepa/main.py
@@ -19,7 +19,7 @@ from eb_jepa.architectures import (
     Projector,
     ResNet5,
     ResUNet,
-    StateOnlyPredictor,
+    SimplePredictor,
 )
 from eb_jepa.datasets.moving_mnist import MovingMNISTDet
 from eb_jepa.image_decoder import ImageDecoder
@@ -129,7 +129,7 @@ def run(
     logger.info("Initializing model...")
     encoder = ResNet5(cfg.model.dobs, cfg.model.henc, cfg.model.dstc)
     predictor_model = ResUNet(2 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
-    predictor = StateOnlyPredictor(predictor_model, context_length=2)
+    predictor = SimplePredictor(predictor_model, context_length=2)
     projector = Projector(f"{cfg.model.dstc}-{cfg.model.dstc*4}-{cfg.model.dstc*4}")
     regularizer = VCLoss(cfg.loss.std_coeff, cfg.loss.cov_coeff, proj=projector)
     ploss = SquareLossSeq(projector)

--- a/plan.txt
+++ b/plan.txt
@@ -1,0 +1,126 @@
+Plan: Fix parallel unroll to use real states as context anchors
+Context
+The unroll() parallel mode in JEPA has a correctness bug: after each iteration, it re-feeds only the first context_length real states on the left, replacing all other positions with predictions. This means that from iteration 2 onward, some context entries are predicted states where real ground truth exists and should be used instead.
+
+For example with context_length=2, in iteration 2 the pair (s*(3), s*(4)) → s**(5) uses a predicted s*(3) as the left anchor even though real s_3 is available.
+
+The fix moves context-window stacking from StateOnlyPredictor.forward into unroll(), giving the unroll loop full control over which states are real vs predicted. Each iteration then uses:
+
+context_length - 1 real ground-truth state slices (shifted by k)
+1 predicted entry (the output of the previous iteration) as the rightmost context slot
+Mathematical derivation (key shapes)
+With T encoded frames and context_length = L:
+
+At step k (0-indexed):
+
+T' = T - L + 1 - k
+State buffer: L tensors each (B, C, T', H, W)
+i = 0..L-2: state[:, :, k+i : k+i+T'] (real GT)
+i = L-1: prev_predictions from step k-1 (same shape); at k=0 also uses real GT
+Predictor output: (B, C, T', H, W)
+prev_predictions = predictor_out[:, :, :-1] → (B, C, T'-1, H, W) for next step
+Loss target: state[:, :, L+k : T] has T - L - k = T' - 1 frames ✓ (dimensions match)
+Files to modify
+1. eb_jepa/jepa.py — unroll() parallel mode (lines 141–157)
+Replace the loop body with a rolling context buffer:
+
+
+if unroll_mode == "parallel":
+    prev_predictions = None
+    for k in range(nsteps):
+        T_prime = T - context_length + 1 - k
+
+        # Build state context buffer:
+        # - first L-1 slots: real GT states shifted by k
+        # - last slot: prev_predictions (or real GT on first step)
+        if k == 0:
+            state_slices = [state[:, :, i : i + T_prime] for i in range(context_length)]
+        else:
+            state_slices = [
+                state[:, :, k + i : k + i + T_prime] for i in range(context_length - 1)
+            ]
+            state_slices.append(prev_predictions)
+
+        state_buffer = torch.cat(state_slices, dim=1)  # (B, C*L, T', H, W)
+
+        # Build action buffer (same window logic, if actions present)
+        if actions_encoded is not None:
+            action_slices = [
+                actions_encoded[:, :, k + i : k + i + T_prime]
+                for i in range(context_length)
+            ]
+            action_buffer = torch.cat(action_slices, dim=1)
+        else:
+            action_buffer = None
+
+        predictor_out = self.predictor(state_buffer, action_buffer)  # (B, C, T', H, W)
+        prev_predictions = predictor_out[:, :, :-1]  # (B, C, T'-1, H, W)
+
+        if return_all_steps:
+            all_steps.append(prev_predictions)
+
+        if compute_loss:
+            target = state[:, :, context_length + k : T]  # (B, C, T'-1, H, W)
+            ploss += self.predcost(target, prev_predictions) / nsteps
+
+    predicted_states = prev_predictions  # return last step's predictions
+Also: at line 122, B, C, T, H, W = state.shape must be extracted before the branch (it's already used by the autoregressive branch so this is safe; just make sure it's present at the top of the unroll logic after encoding).
+
+2. eb_jepa/architectures.py — Simplify / remove StateOnlyPredictor
+StateOnlyPredictor.forward currently does the context-stacking:
+
+
+prev_state = x[:, :, :-1]
+next_state = x[:, :, 1:]
+combined_xa = torch.cat((prev_state, next_state), dim=1)
+return self.predictor(combined_xa)
+After the change, unroll() builds the stacked state_buffer before calling the predictor. StateOnlyPredictor becomes a pass-through that just ignores actions:
+
+Option A (minimal change): Simplify StateOnlyPredictor.forward:
+
+
+def forward(self, state_buffer, actions_buffer):
+    # Context stacking is now handled in unroll(); just forward the buffer.
+    # actions are ignored for state-only prediction.
+    return self.predictor(state_buffer)
+Option B (user's preferred): Remove StateOnlyPredictor entirely and update SimplePredictor to handle a=None:
+
+
+class SimplePredictor(nn.Module):
+    def forward(self, x, a):
+        if a is not None:
+            return self.predictor(torch.cat([x, a], dim=1))
+        return self.predictor(x)
+Then in video_jepa/main.py and tests, replace StateOnlyPredictor(...) with SimplePredictor(...).
+
+Recommendation: Option B is cleaner and matches the user's intent. Note: the user's proposed StateOnlyPredictor.forward called self.predictor(state_buffer, actions_buffer) which would fail since ResUNet takes a single tensor — Option B avoids this issue entirely.
+
+3. examples/video_jepa/main.py (line 131)
+If Option B is chosen, update import and construction:
+
+
+# Before:
+from eb_jepa.architectures import StateOnlyPredictor
+predictor_model = ResUNet(2 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
+predictor = StateOnlyPredictor(predictor_model, context_length=2)
+
+# After:
+from eb_jepa.architectures import SimplePredictor
+predictor_model = ResUNet(2 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
+predictor = SimplePredictor(predictor_model, context_length=2)
+No architecture change: ResUNet input channels = context_length * dstc = 2 * dstc is unchanged.
+
+4. tests/test_jepa_output_formats.py
+Update imports: replace StateOnlyPredictor with SimplePredictor
+Update create_video_jepa_model() to use SimplePredictor
+The existing shape assertions in test_unroll_parallel_mode_output_format check preds[0].shape[2] == T - context_length, which still holds (step 0: T'-1 = T - context_length) ✓
+Shapes of preds[1], preds[2], ... decrease by 1 each step (T-L-1, T-L-2, ...) — no assertions on those in existing tests, so they pass as-is
+Return shape of predicted_states when return_all_steps=False changes from (B, C, T) to (B, C, T-L-nsteps+1) — verify no assertions rely on this
+Verification
+Run existing tests: python tests/test_jepa_output_formats.py — all parallel and autoregressive tests should pass
+Manually verify step-0 predictions are identical to the old code (same input context, same output)
+Verify step-1 context: for context_length=2, at step k=1:
+Slot 0 = state[:, :, 1:T'] (real s_1, ..., s_{T-2}) ← shifted right by 1 vs step 0
+Slot 1 = prev_predictions from step 0 (s*_2, ..., s*_{T-2})
+Predictor at position j receives [s_{j+1}, s*_{j+2}] — both the anchor is real and only the right edge is predicted ✓
+Verify dimensions: at each step, target.shape[2] == prev_predictions.shape[2] (should be T - L - k)

--- a/plan.txt
+++ b/plan.txt
@@ -124,3 +124,133 @@ Slot 0 = state[:, :, 1:T'] (real s_1, ..., s_{T-2}) ← shifted right by 1 vs st
 Slot 1 = prev_predictions from step 0 (s*_2, ..., s*_{T-2})
 Predictor at position j receives [s_{j+1}, s*_{j+2}] — both the anchor is real and only the right edge is predicted ✓
 Verify dimensions: at each step, target.shape[2] == prev_predictions.shape[2] (should be T - L - k)
+
+
+=== next changes === 
+
+Fix parallel unroll to use real states as context anchors
+Context
+The unroll() parallel mode in JEPA has a correctness bug: after each iteration, it re-feeds only the first context_length real states on the left, replacing all other positions with predictions. This means that from iteration 2 onward, some context entries are predicted states where real ground truth exists and should be used instead.
+
+For example with context_length=2, in iteration 2 the pair (s*(3), s*(4)) → s**(5) uses a predicted s*(3) as the left anchor even though real s_3 is available.
+
+The fix moves context-window stacking from StateOnlyPredictor.forward into unroll(), giving the unroll loop full control over which states are real vs predicted. Each iteration then uses:
+
+context_length - 1 real ground-truth state slices (shifted by k)
+1 predicted entry (the output of the previous iteration) as the rightmost context slot
+Mathematical derivation (key shapes)
+With T encoded frames and context_length = L:
+
+At step k (0-indexed):
+
+T' = T - L + 1 - k
+State buffer: L tensors each (B, C, T', H, W)
+i = 0..L-2: state[:, :, k+i : k+i+T'] (real GT)
+i = L-1: prev_predictions from step k-1 (same shape); at k=0 also uses real GT
+Predictor output: (B, C, T', H, W)
+prev_predictions = predictor_out[:, :, :-1] → (B, C, T'-1, H, W) for next step
+Loss target: state[:, :, L+k : T] has T - L - k = T' - 1 frames ✓ (dimensions match)
+Files to modify
+1. eb_jepa/jepa.py — unroll() parallel mode (lines 141–157)
+Replace the loop body with a rolling context buffer:
+
+
+if unroll_mode == "parallel":
+    prev_predictions = None
+    for k in range(nsteps):
+        T_prime = T - context_length + 1 - k
+
+        # Build state context buffer:
+        # - first L-1 slots: real GT states shifted by k
+        # - last slot: prev_predictions (or real GT on first step)
+        if k == 0:
+            state_slices = [state[:, :, i : i + T_prime] for i in range(context_length)]
+        else:
+            state_slices = [
+                state[:, :, k + i : k + i + T_prime] for i in range(context_length - 1)
+            ]
+            state_slices.append(prev_predictions)
+
+        state_buffer = torch.cat(state_slices, dim=1)  # (B, C*L, T', H, W)
+
+        # Build action buffer (same window logic, if actions present)
+        if actions_encoded is not None:
+            action_slices = [
+                actions_encoded[:, :, k + i : k + i + T_prime]
+                for i in range(context_length)
+            ]
+            action_buffer = torch.cat(action_slices, dim=1)
+        else:
+            action_buffer = None
+
+        predictor_out = self.predictor(state_buffer, action_buffer)  # (B, C, T', H, W)
+        prev_predictions = predictor_out[:, :, :-1]  # (B, C, T'-1, H, W)
+
+        if return_all_steps:
+            all_steps.append(prev_predictions)
+
+        if compute_loss:
+            target = state[:, :, context_length + k : T]  # (B, C, T'-1, H, W)
+            ploss += self.predcost(target, prev_predictions) / nsteps
+
+    predicted_states = prev_predictions  # return last step's predictions
+Also: at line 122, B, C, T, H, W = state.shape must be extracted before the branch (it's already used by the autoregressive branch so this is safe; just make sure it's present at the top of the unroll logic after encoding).
+
+2. eb_jepa/architectures.py — Simplify / remove StateOnlyPredictor
+StateOnlyPredictor.forward currently does the context-stacking:
+
+
+prev_state = x[:, :, :-1]
+next_state = x[:, :, 1:]
+combined_xa = torch.cat((prev_state, next_state), dim=1)
+return self.predictor(combined_xa)
+After the change, unroll() builds the stacked state_buffer before calling the predictor. StateOnlyPredictor becomes a pass-through that just ignores actions:
+
+Option A (minimal change): Simplify StateOnlyPredictor.forward:
+
+
+def forward(self, state_buffer, actions_buffer):
+    # Context stacking is now handled in unroll(); just forward the buffer.
+    # actions are ignored for state-only prediction.
+    return self.predictor(state_buffer)
+Option B (user's preferred): Remove StateOnlyPredictor entirely and update SimplePredictor to handle a=None:
+
+
+class SimplePredictor(nn.Module):
+    def forward(self, x, a):
+        if a is not None:
+            return self.predictor(torch.cat([x, a], dim=1))
+        return self.predictor(x)
+Then in video_jepa/main.py and tests, replace StateOnlyPredictor(...) with SimplePredictor(...).
+
+Recommendation: Option B is cleaner and matches the user's intent. Note: the user's proposed StateOnlyPredictor.forward called self.predictor(state_buffer, actions_buffer) which would fail since ResUNet takes a single tensor — Option B avoids this issue entirely.
+
+3. examples/video_jepa/main.py (line 131)
+If Option B is chosen, update import and construction:
+
+
+# Before:
+from eb_jepa.architectures import StateOnlyPredictor
+predictor_model = ResUNet(2 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
+predictor = StateOnlyPredictor(predictor_model, context_length=2)
+
+# After:
+from eb_jepa.architectures import SimplePredictor
+predictor_model = ResUNet(2 * cfg.model.dstc, cfg.model.hpre, cfg.model.dstc)
+predictor = SimplePredictor(predictor_model, context_length=2)
+No architecture change: ResUNet input channels = context_length * dstc = 2 * dstc is unchanged.
+
+4. tests/test_jepa_output_formats.py
+Update imports: replace StateOnlyPredictor with SimplePredictor
+Update create_video_jepa_model() to use SimplePredictor
+The existing shape assertions in test_unroll_parallel_mode_output_format check preds[0].shape[2] == T - context_length, which still holds (step 0: T'-1 = T - context_length) ✓
+Shapes of preds[1], preds[2], ... decrease by 1 each step (T-L-1, T-L-2, ...) — no assertions on those in existing tests, so they pass as-is
+Return shape of predicted_states when return_all_steps=False changes from (B, C, T) to (B, C, T-L-nsteps+1) — verify no assertions rely on this
+Verification
+Run existing tests: python tests/test_jepa_output_formats.py — all parallel and autoregressive tests should pass
+Manually verify step-0 predictions are identical to the old code (same input context, same output)
+Verify step-1 context: for context_length=2, at step k=1:
+Slot 0 = state[:, :, 1:T'] (real s_1, ..., s_{T-2}) ← shifted right by 1 vs step 0
+Slot 1 = prev_predictions from step 0 (s*_2, ..., s*_{T-2})
+Predictor at position j receives [s_{j+1}, s*_{j+2}] — both the anchor is real and only the right edge is predicted ✓
+Verify dimensions: at each step, target.shape[2] == prev_predictions.shape[2] (should be T - L - k)

--- a/tests/test_jepa_output_formats.py
+++ b/tests/test_jepa_output_formats.py
@@ -22,7 +22,7 @@ from eb_jepa.architectures import (
     ResNet5,
     ResUNet,
     RNNPredictor,
-    StateOnlyPredictor,
+    SimplePredictor,
 )
 from eb_jepa.jepa import JEPA
 from eb_jepa.losses import SquareLossSeq, VC_IDM_Sim_Regularizer, VCLoss
@@ -48,7 +48,7 @@ def create_video_jepa_model(device="cpu"):
 
     encoder = ResNet5(dobs, henc, dstc)
     predictor_model = ResUNet(2 * dstc, hpre, dstc)
-    predictor = StateOnlyPredictor(predictor_model, context_length=2)
+    predictor = SimplePredictor(predictor_model, context_length=2)
     projector = Projector(f"{dstc}-{dstc*4}-{dstc*4}")
     regularizer = VCLoss(std_coeff=10.0, cov_coeff=100.0, proj=projector)
     ploss = SquareLossSeq(projector)


### PR DESCRIPTION
## Summary

Fixes #10 — correctness bug in `unroll()` parallel mode where predicted states were used as
context even when real ground-truth states were available.

### The Bug

In the unroll loop, in the parallel mode, after each iteration the context window was rebuilt using only the
first `context_length` real states from the start of the sequence. 

This is how the predicted states and the real states were concatenated
predicted_states = torch.cat(
(state[:, :, :context_length], predicted_states), dim=2
)

With context_length=2 and StateOnlyPredictor (which predicts from pairs of consecutive states), the predicted_states at iteration 2 looks like this:
[s1, s2, s*(3), s*(4), s*(5), ...]

The predictor then forms pairs:
(s1, s2) → s**(3) — both real 
(s2, s*(3)) → s**(4) — one real, one predicted ✓
(s*(3), s*(4)) → s**(5) — both predicted ✗

From step k=1 onward, some
context slots held predicted states `s*` even though the actual ground-truth state `s` existed
and should have been used.

### The Fix

Context-window stacking is moved from `StateOnlyPredictor.forward` into `unroll()`, giving the
loop full control over which slots are real vs predicted.

At each step k, the context buffer is built as:
- Slots 0..L-2: real ground-truth states shifted by k (`state[:, :, k+i : k+i+T']`)
- Slot L-1: `prev_predictions` from the previous step (only the rightmost slot is ever predicted)

This ensures the maximum possible grounding in real observations at every step.

### Context Length Generalization

The old `StateOnlyPredictor.forward` hard-coded a context of exactly 2 by always pairing
`x[:, :, :-1]` (prev) with `x[:, :, 1:]` (next) and concatenating them. This silently capped
the effective context window at 2, regardless of what `context_length` was set to in the config.

With the fix, context stacking is done in `unroll()` using the configured `context_length`
(any value ≥ 1), so longer context windows now work correctly.

### Changes

#### `eb_jepa/jepa.py`
- Replaced the parallel unroll loop body with a rolling deque-style buffer approach
- At step k=0: all context slots use real GT (same as before)
- At step k>0: first L-1 slots use real GT shifted by k; last slot uses prev_predictions
- Loss target and prev_predictions shapes are correctly trimmed each step

#### `eb_jepa/architectures.py`
- Removed `StateOnlyPredictor` (context stacking is no longer the predictor's responsibility)
- Updated `SimplePredictor` to accept `a=None` for state-only prediction (cleaner API)
- Added `ActionEncoder`: encodes 2D actions into spatial tensors `(B, C, T, H, W)` for use
  with spatial predictors
- Fixed `ActionEncoder.__init__` to properly declare parameters

#### `eb_jepa/state_decoder.py`
- Added `SpatialMLPXYHead` which flattens `C×H×W` before the MLP, for use with encoders
  (like ResNet5) that preserve spatial resolution

#### `examples/video_jepa/main.py` + `tests/`
- Updated imports: `StateOnlyPredictor` → `SimplePredictor`

#### New example: `examples/ac_video_parallel_jepa/`
- Demonstrates the corrected parallel unroll with action conditioning
- Uses ResNet5 encoder (preserves spatial structure) instead of ImpalaEncoder
- Uses ResUNet + SimplePredictor (non-recurrent) as the predictor
- ActionEncoder broadcasts 2D actions to spatial format
- SpatialMLPXYHead as the probe head
- Full training setup with VC + IDM + time-similarity regularization
- Config: context window of 3, configurable via `ctxtwind`/`hactenc`